### PR TITLE
SVCPostSend/Recv: Expose set API for more flexibility

### DIFF
--- a/src/main/java/com/ibm/disni/rdma/verbs/SVCPostRecv.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/SVCPostRecv.java
@@ -22,6 +22,7 @@
 package com.ibm.disni.rdma.verbs;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * The Class SVCPostRecv.
@@ -38,7 +39,17 @@ public abstract class SVCPostRecv implements StatefulVerbCall<SVCPostRecv> {
 	 * @throws Exception in case the index is out-of-bound.
 	 */
 	public abstract RecvWRMod getWrMod(int index) throws IOException;
-	
+
+	/**
+	 * Set work requests of this SVC object.
+	 *
+	 * @param qp the qp
+	 * @param wrList list of WRs
+	 * @return
+	 * @throws Exception in case the wrList is null.
+	 */
+	public abstract void set(IbvQP qp, List<IbvRecvWR> wrList);
+
 	/**
 	 * Provides access methods to modify a given work-request belonging to this SVC object.
 	 */

--- a/src/main/java/com/ibm/disni/rdma/verbs/SVCPostSend.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/SVCPostSend.java
@@ -22,6 +22,7 @@
 package com.ibm.disni.rdma.verbs;
 
 import java.io.IOException;
+import java.util.List;
 
 /**
  * The Class SVCPostSend.
@@ -38,7 +39,17 @@ public abstract class SVCPostSend implements StatefulVerbCall<SVCPostSend> {
 	 * @throws Exception in case the index is out-of-bound.
 	 */
 	public abstract SendWRMod getWrMod(int index) throws IOException;
-	
+
+	/**
+	 * Set work requests of this SVC object.
+	 *
+	 * @param qp the qp
+	 * @param wrList list of WRs
+	 * @return
+	 * @throws Exception in case the wrList is null.
+	 */
+	public abstract void set(IbvQP qp, List<IbvSendWR> wrList);
+
 	/**
 	 * Provides access methods to modify a given work-request belonging to this SVC object.
 	 */

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostRecvCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostRecvCall.java
@@ -54,7 +54,8 @@ public class NatPostRecvCall extends SVCPostRecv {
 		this.sgeNatList = new ArrayList<IbvSge>();
 		this.valid = false;
 	}
-	
+
+	@Override
 	public void set(IbvQP qp, List<IbvRecvWR> wrList) {
 		this.qp = (NatIbvQP) qp;
 		wrNatList.clear();
@@ -78,12 +79,17 @@ public class NatPostRecvCall extends SVCPostRecv {
 				sgeOffset += recvWR.getSg_list().size()*NatIbvSge.CSIZE;
 			}
 		}
-		if (cmd != null){
+
+		if (cmd != null && cmd.size() < size){
 			memAlloc.put(cmd);
 			cmd = null;
 		}
-		this.cmd = memAlloc.allocate(size);
-		
+		if (cmd == null) {
+			this.cmd = memAlloc.allocate(size);
+		} else {
+			cmd.getBuffer().clear();
+		}
+
 		for (NatIbvRecvWR natWR : wrNatList){
 			natWR.shiftAddress(cmd.address());
 		}
@@ -108,7 +114,7 @@ public class NatPostRecvCall extends SVCPostRecv {
 		}
 		int ret = nativeDispatcher._postRecv(qp.getObjId(), cmd.address());
 		if (ret != 0){
-			throw new IOException("Post recv failed");
+			throw new IOException("Post recv failed ret: " + ret);
 		}
 		return this;
 	}

--- a/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostSendCall.java
+++ b/src/main/java/com/ibm/disni/rdma/verbs/impl/NatPostSendCall.java
@@ -57,6 +57,7 @@ public class NatPostSendCall extends SVCPostSend {
 		this.valid = false;
 	}
 
+	@Override
 	public void set(IbvQP qp, List<IbvSendWR> wrList) {
 		this.qp = (NatIbvQP) qp;
 		wrNatList.clear();
@@ -85,12 +86,16 @@ public class NatPostSendCall extends SVCPostSend {
 			sgeOffset += sendWR.getSg_list().size()*NatIbvSge.CSIZE;
 		}
 		
-		if (cmd != null){
+		if (cmd != null && cmd.size() < size){
 			memAlloc.put(cmd);
 			cmd = null;
-		}		
-		this.cmd = memAlloc.allocate(size);
-		
+		}
+		if (cmd == null) {
+			this.cmd = memAlloc.allocate(size);
+		} else {
+			cmd.getBuffer().clear();
+		}
+
 		for (NatIbvSendWR natWR : wrNatList){
 			natWR.shiftAddress(cmd.address());
 		}
@@ -113,7 +118,7 @@ public class NatPostSendCall extends SVCPostSend {
 		}
 		int ret = nativeDispatcher._postSend(qp.getObjId(), cmd.address());
 		if (ret != 0){
-			throw new IOException("Post send failed");
+			throw new IOException("Post send failed ret: " + ret);
 		}
 		return this;
 	}


### PR DESCRIPTION
Allow users with more flexibility on using and reusing the
"SVCPostSend", "SVCPostRecv" without free/allocate memory unnecessarily

Signed-off-by: Vu Pham <vu@mellanox.com>